### PR TITLE
Keep pending completion and execute them when token is resolved

### DIFF
--- a/Sources/Shared/AuthService.swift
+++ b/Sources/Shared/AuthService.swift
@@ -65,7 +65,7 @@ import Foundation
     refreshToken() { [weak self] accessToken, error in
       guard let weakSelf = self else { return }
 
-      for completion in weakSelf.pendingTokenCompletions {
+      weakSelf.pendingTokenCompletions.forEach { completion in
         completion(accessToken, error)
       }
 

--- a/Sources/Shared/AuthService.swift
+++ b/Sources/Shared/AuthService.swift
@@ -8,6 +8,7 @@ import Foundation
   public let config: AuthConfig
   public var locker: Lockable
   private var pendingTokenCompletions = [Completion]()
+  private var pendingToken = false
 
   public var tokenIsExpired: Bool {
     return locker.expiryDate?.timeIntervalSinceNow < config.minimumValidity
@@ -57,6 +58,10 @@ import Foundation
 
     pendingTokenCompletions.append(completion)
 
+    guard !pendingToken else { return }
+
+    pendingToken = true
+
     refreshToken() { [weak self] accessToken, error in
       guard let weakSelf = self else { return }
 
@@ -65,6 +70,7 @@ import Foundation
       }
 
       weakSelf.pendingTokenCompletions = []
+      weakSelf.pendingToken = false
     }
   }
 


### PR DESCRIPTION
@zenangst @RamonGilabert The idea is to get the access token using `func accessToken(completion: Completion)` function, and if we have to refresh a token, all the completions from multiple requests will be added to the queue and then executed when a token is resolved.