### PR TITLE
Fix "can't extract expiration date" bug

### DIFF
--- a/Sources/Shared/AuthConfig.swift
+++ b/Sources/Shared/AuthConfig.swift
@@ -13,8 +13,8 @@ import Foundation
   public var expiryDate: (data: [String : AnyObject]) -> NSDate? = { data -> NSDate? in
     var date: NSDate?
 
-    if let expiresIn = data["expires_in"] as? Double {
-      date = NSDate(timeIntervalSinceNow: expiresIn)
+    if let expiresIn = data["expires_in"] {
+      date = NSDate(timeIntervalSinceNow: expiresIn.doubleValue)
     }
 
     return date


### PR DESCRIPTION
In the project I’m working on the original code was unable to extract the (otherwise correct) expiration date from the authentication server’s response (Azure AD). The modified code works just fine.