### PR TITLE
Add authorize() call if token refresh failed

### DIFF
--- a/Sources/Shared/AuthService.swift
+++ b/Sources/Shared/AuthService.swift
@@ -81,12 +81,16 @@ import Foundation
             completion(nil, Error.AuthServiceDeallocated.toNSError())
             return
           }
-
-          weakSelf.pendingTokenCompletions.forEach { completion in
-            completion(accessToken, error)
+          
+          if error != nil {
+            weakSelf.authorize()
+          } else {
+            weakSelf.pendingTokenCompletions.forEach { completion in
+              completion(accessToken, error)
+            }
+            
+            weakSelf.pendingTokenCompletions = []
           }
-
-          weakSelf.pendingTokenCompletions = []
         }
       }
     }
@@ -104,6 +108,12 @@ import Foundation
 
     accessToken(parameters: ["code" : code]) { [weak self] accessToken, error in
       completion(accessToken, error)
+      if error == nil {
+        self?.pendingTokenCompletions.forEach { completion in
+          completion(accessToken, error)
+        }
+        self?.pendingTokenCompletions = []
+      }
       self?.config.webView.close?()
     }
 


### PR DESCRIPTION
There is an edge case not handled by the current code. I’ve run into this issue on an earlier project (using a home-grown OAuth solution).

If the user successfully authorizes, but then doesn’t use the app for at least two weeks, the refresh token also expires (at least with Azure AD). In this case next time app is opened and an access token refresh is attempted, it will fail. In the other project I’ve handled this edge case with an attempt to authorize again (and perform any code block waiting for the access token, if succeeded). The aim was to provide as smooth UX as possible if it went wrong.

I’m not sure if the solution in this PR is the right one (I’m happy to share the Objective-C code from that earlier project with you), but we should get started somewhere.