### PR TITLE
Add deauthorize()

### DIFF
--- a/Sources/Shared/AuthConfig.swift
+++ b/Sources/Shared/AuthConfig.swift
@@ -7,6 +7,7 @@ import Foundation
   public var accessTokenUrl: NSURL
   public var authorizeURL: NSURL?
   public var changeUserURL: NSURL?
+  public var deauthorizeURL: NSURL?
   public var redirectURI: String?
   public var minimumValidity: NSTimeInterval = 5 * 60
 

--- a/Sources/Shared/AuthService.swift
+++ b/Sources/Shared/AuthService.swift
@@ -49,6 +49,16 @@ import Foundation
 
     return true
   }
+  
+  public func deauthorize(completion: () -> ()) -> Bool {
+    guard let URL = config.deauthorizeURL else { return false }
+    
+    locker.clear()
+    config.webView.open(URL)
+    completion()
+    
+    return true
+  }
 
   // MARK: - Tokens
 


### PR DESCRIPTION
I think it’d be useful to add a way to logout/deauthorize. The completion is to let the client to do its own post-logout clean-up. Unfortunately the browser controller can’t be closed automagically in this case because we don’t get notified about the event.