### PR TITLE
Improve/error handling

### DIFF
--- a/Sources/Shared/Library/Error.swift
+++ b/Sources/Shared/Library/Error.swift
@@ -5,12 +5,8 @@ import Foundation
   case NoConfigFound = -2
   case NoRefreshTokenFound = -3
   case TokenRequestFailed = -4
-  case NoDataInResponse = -5
-  case NoAccessTokenInResponse = -6
-  case NoRefreshTokenInResponse = -7
-  case NoExpiryDateInResponse = -8
-  case TokenRequestAlreadyStarted = -9
-  case AuthServiceDeallocated = -10
+  case TokenRequestAlreadyStarted = -5
+  case AuthServiceDeallocated = -6
 
   // MARK: - Helpers
 
@@ -26,14 +22,6 @@ import Foundation
       message = "No refresh token in keychain"
     case TokenRequestFailed:
       message = "Token request error"
-    case NoDataInResponse:
-      message = "No data in response"
-    case NoAccessTokenInResponse:
-      message = "No access token in response"
-    case NoRefreshTokenInResponse:
-      message = "No refresh token in response"
-    case NoExpiryDateInResponse:
-      message = "No expiration date in response"
     case TokenRequestAlreadyStarted:
       message = "Token request has already been started"
     case AuthServiceDeallocated:

--- a/Sources/Shared/Networking/NetworkTasks.swift
+++ b/Sources/Shared/Networking/NetworkTasks.swift
@@ -20,19 +20,19 @@ struct TokenNetworkTask: NetworkTaskable, NetworkQueueable {
     guard let accessToken = data["access_token"] as? String else {
       locker.clear()
       NSLog("\(data)")
-      throw Error.NoAccessTokenInResponse.toNSError()
+      throw Error.TokenRequestFailed.toNSError()
     }
 
     guard let refreshToken = data["refresh_token"] as? String else {
       locker.clear()
       NSLog("\(data)")
-      throw Error.NoRefreshTokenInResponse.toNSError()
+      throw Error.TokenRequestFailed.toNSError()
     }
 
     guard let expiryDate = config.expiryDate(data: data) else {
       locker.clear()
       NSLog("\(data)")
-      throw Error.NoExpiryDateInResponse.toNSError()
+      throw Error.TokenRequestFailed.toNSError()
     }
 
     locker.accessToken = accessToken

--- a/Sources/Shared/Protocols/NetworkRequestable.swift
+++ b/Sources/Shared/Protocols/NetworkRequestable.swift
@@ -15,21 +15,15 @@ extension NetworkRequestable {
         return
       }
 
-      guard let value = response.result.value else {
-        completion(result: .Failure(Error.NoDataInResponse.toNSError()))
-        return
-      }
+      guard response.response?.statusCode != 401 else {
+        var userInfo: [String: AnyObject] = [:]
+        if let statusCode = response.response?.statusCode {
+          userInfo = [
+            "statusCode" : statusCode
+          ]
+        }
 
-      if let JSON = value as? JSONDictionary, errorDictionary = JSON["error"] as? JSONDictionary {
-        let error = Error.TokenRequestFailed.toNSError(
-          JSON["error_description"] as? String, userInfo: errorDictionary)
-
-        completion(result: .Failure(error))
-        return
-      }
-
-      guard response.response?.statusCode == 200 else {
-        completion(result: .Failure(Error.TokenRequestFailed.toNSError()))
+        completion(result: .Failure(Error.TokenRequestFailed.toNSError(userInfo: userInfo)))
         return
       }
 

--- a/Sources/Shared/Protocols/NetworkTaskable.swift
+++ b/Sources/Shared/Protocols/NetworkTaskable.swift
@@ -14,7 +14,7 @@ extension NetworkTaskable {
       switch result {
       case .Success(let data):
         guard let data = data as? Input else {
-          completion(.Failure(Error.NoDataInResponse.toNSError()))
+          completion(.Failure(Error.TokenRequestFailed.toNSError()))
           return
         }
 


### PR DESCRIPTION
This PR reduces the amount of error types that OhMyAuth will return. It also simplifies the evaluation of network errors, it will trigger a `Error.TokenRequestFailed` with the status code in the `userInfo` if the status code is 401.