### PR TITLE
Handle info in 401

### DIFF
--- a/Sources/Shared/AuthConfig.swift
+++ b/Sources/Shared/AuthConfig.swift
@@ -2,6 +2,9 @@ import Foundation
 
 @objc public class AuthConfig: NSObject {
 
+  // Parse network response to userInfo
+  public static var parse: ((response: [String: AnyObject]) -> [String: AnyObject]?)?
+
   public var clientId: String
   public var accessGrantType: String
   public var accessTokenUrl: NSURL

--- a/Sources/Shared/Protocols/NetworkRequestable.swift
+++ b/Sources/Shared/Protocols/NetworkRequestable.swift
@@ -17,10 +17,14 @@ extension NetworkRequestable {
 
       guard response.response?.statusCode != 401 else {
         var userInfo: [String: AnyObject] = [:]
+
+        if let value = response.result.value as? [String: AnyObject],
+          parsedValue = AuthConfig.parse?(response: value) {
+          userInfo = parsedValue
+        }
+
         if let statusCode = response.response?.statusCode {
-          userInfo = [
-            "statusCode" : statusCode
-          ]
+          userInfo["statusCode"] = statusCode
         }
 
         completion(result: .Failure(Error.TokenRequestFailed.toNSError(userInfo: userInfo)))


### PR DESCRIPTION
For case of 401, the network response may include some more info that we want to notify in the completion handler, rather than just the `statusCode`

So this allows consumer to specify the `parse` function to do that