### PR TITLE
Feature: disable expiry date check

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-github "Alamofire/Alamofire" "3.4.1"
-github "auth0/JWTDecode.swift" "b72153762e3c52af312ca70a8eba658847eff2e3"
+github "Alamofire/Alamofire" "3.4.2"
+github "auth0/JWTDecode.swift" "3087ee7fbcafdf316b1a4ccf0d0363aa9df6c5df"
 github "hyperoslo/Keychain" "f8197b27fe34774b72046b0ec4a24e517e1bb79c"
 github "Quick/Nimble" "v4.1.0"
 github "Quick/Quick" "v0.9.3"

--- a/Sources/Shared/AuthConfig.swift
+++ b/Sources/Shared/AuthConfig.swift
@@ -14,6 +14,7 @@ import Alamofire
   public var deauthorizeURL: NSURL?
   public var redirectURI: String?
   public var minimumValidity: NSTimeInterval = 5 * 60
+  public var checkExpiry = true
 
   public var expiryDate: (data: [String : AnyObject]) -> NSDate? = { data -> NSDate? in
     var date: NSDate?

--- a/Sources/Shared/AuthService.swift
+++ b/Sources/Shared/AuthService.swift
@@ -74,11 +74,9 @@ import Foundation
         return
       }
 
-      if !force {
-        guard weakSelf.tokenIsExpired else {
-          completion(weakSelf.locker.accessToken, nil)
-          return
-        }
+      guard force || (weakSelf.tokenIsExpired && weakSelf.config.checkExpiry) else {
+        completion(weakSelf.locker.accessToken, nil)
+        return
       }
 
       weakSelf.pendingTokenCompletions.append(completion)


### PR DESCRIPTION
When you set `checkExpiry` to false on config, token will "never be expired" locally, so request will be executed unless `force` is true.