### PR TITLE
Fix logic properly this time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
 - brew update
 - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
 - if brew outdated | grep -qx carthage; then brew upgrade carthage; fi
-- travis_wait 35 carthage update --platform iOS,Mac
+- travis_wait 35 carthage bootstrap --platform iOS,Mac
 
 script:
 - xctool clean build -project OhMyAuth.xcodeproj -scheme OhMyAuth-iOS -sdk iphonesimulator

--- a/Sources/Shared/AuthService.swift
+++ b/Sources/Shared/AuthService.swift
@@ -17,7 +17,9 @@ import Foundation
       return true
     }
 
-    let expired = expiryDate.timeIntervalSince1970 <= NSDate().timeIntervalSince1970 - config.minimumValidity
+    let expiredTime = expiryDate.timeIntervalSince1970
+    let timeNow = NSDate().timeIntervalSince1970 - config.minimumValidity
+    let expired = timeNow >= expiredTime
 
     return expired
   }

--- a/Sources/Shared/AuthService.swift
+++ b/Sources/Shared/AuthService.swift
@@ -17,8 +17,9 @@ import Foundation
       return true
     }
 
-    return expiryDate.timeIntervalSinceReferenceDate
-      >= NSDate.timeIntervalSinceReferenceDate() - config.minimumValidity
+    let expired = expiryDate.timeIntervalSince1970 <= NSDate().timeIntervalSince1970 - config.minimumValidity
+
+    return expired
   }
 
   // MARK: - Initialization


### PR DESCRIPTION
It seems like we had a brain-fart earlier when trying to fix this logic.
If you analysis the statement it should be pretty straight forward to see that the `expiryDate` should be in the past and not the future. Otherwise it would cause it to always refresh the token, unless of course it was expired and then it would end up doing nothing.