### PR TITLE
Release 1.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "hyperoslo/Keychain" "swift-3"
+github "hyperoslo/Keychain" "master"
 github "auth0/JWTDecode.swift" "2.0.0"
 github "hyperoslo/Malibu"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,5 @@
 github "auth0/JWTDecode.swift" "2.0.0"
-github "hyperoslo/Keychain" "aba620997062a2082a9d1a57fb5c81e4e0fe79df"
-github "vadymmarkov/When" "2.0.0"
-github "hyperoslo/Malibu" "2.0.1"
+github "hyperoslo/Keychain" "1c53e133802bd043d830500db3066561d17f7aba"
+github "ReactiveX/RxSwift" "3.3.0"
+github "vadymmarkov/When" "2.1.1"
+github "hyperoslo/Malibu" "4.0.0"

--- a/OhMyAuth.podspec
+++ b/OhMyAuth.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "OhMyAuth"
   s.summary          = "A short description of OhMyAuth."
-  s.version          = "0.2.0"
+  s.version          = "1.0.0"
   s.homepage         = "https://github.com/hyperoslo/OhMyAuth"
   s.license          = 'MIT'
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }


### PR DESCRIPTION
- Update Cartfile as Keychain swift-3 branch has been merged to master
- We should release `Keychain` first, as this depends on Keychain. However, Keychain name has been registered on cocoapods, we need another podname. However, this PR just bump podspec version to mark this milestone