### PR TITLE
NetworkTasks: Don’t treat missing refresh token as fatal error

### DIFF
--- a/Sources/Shared/Networking/NetworkTasks.swift
+++ b/Sources/Shared/Networking/NetworkTasks.swift
@@ -22,10 +22,8 @@ struct TokenNetworkTask: NetworkTaskable, NetworkQueueable {
       throw OhMyAuthError.tokenRequestFailed.toNSError(userInfo: data)
     }
 
-    guard let refreshToken = data["refresh_token"] as? String else {
-      locker.clear()
-      NSLog("\(data)")
-      throw OhMyAuthError.tokenRequestFailed.toNSError(userInfo: data)
+    if let refreshToken = data["refresh_token"] as? String {
+      locker.refreshToken = refreshToken
     }
 
     guard let expiryDate = config.expiryDate(data) else {
@@ -35,7 +33,6 @@ struct TokenNetworkTask: NetworkTaskable, NetworkQueueable {
     }
 
     locker.accessToken = accessToken
-    locker.refreshToken = refreshToken
     locker.expiryDate = expiryDate
     locker.tokenType = data["token_type"] as? String
 


### PR DESCRIPTION
This change makes it so that a refresh token is no longer required in the data returned from a network request. Some authentication services do not reply with a refresh token, making all requests fail. The change is to only assign the current locker’s refresh token if it exists in the data.